### PR TITLE
Fix ci

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ jobs:
     - uses: actions/checkout@v1
     - uses: actions/setup-python@v1
       with:
-        python-version: '3.6'
+        python-version: '3.7'
         architecture: 'x64'
     - name: Install the library
       run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
         architecture: 'x64'
     - name: Install the library
       run: |
-        pip install https://github.com/muellerzr/nbagile jupyter
+        pip install "git+https://github.com/muellerzr/nbagile" jupyter
         pip install -e .
     - name: Read all notebooks
       run: |

--- a/settings.ini
+++ b/settings.ini
@@ -12,7 +12,7 @@ title = nbagile
 copyright = Zachary Mueller
 license = apache2
 status = 1
-min_python = 3.6
+min_python = 3.7
 audience = Developers
 language = English
 requirements = fastcore==1.3.26 nbdev==1.1.22 astunparse nbverbose


### PR DESCRIPTION
@muellerzr - I tried fixing the CI for nbagile 

Changes made
- Update the installation of library from pip
- Noticed that `from __future__ import annotations` is only available starting from 3.7. So probably you can make a call about whether to stick with 3.6 or move to 3.7 . More details - https://stackoverflow.com/questions/52889746/cant-import-annotations-from-future/52890129
 - changes in settings.in and also CI actions.  
